### PR TITLE
Add generic platform

### DIFF
--- a/dockerfiles/generic/Dockerfile
+++ b/dockerfiles/generic/Dockerfile
@@ -1,0 +1,29 @@
+# using ubuntu as distro having a better set of defaults and packages
+# using 20:04 as it's latest at the moment (June 2020)
+# not using latest explicitly to make it future proof
+FROM ubuntu:20.04
+
+# Install locales and set UTF-8 as default locale to avoid common pitfails
+# Install build-essential and openssl-dev as a minimum set of shared libs and headers
+# This is required to build and link any other language executable
+
+RUN apt-get update && apt-get install -y locales \
+    build-essential openssl libssl-dev ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+WORKDIR /source
+
+COPY ./prepare_build.sh .
+RUN /bin/bash /source/prepare_build.sh
+
+COPY . .
+
+# Note this depends on the entire repository content
+# Build sh might contents and even create `run.sh`
+RUN /bin/bash /source/build.sh
+
+# Use /bin/bash to avoid issues with +x
+ENTRYPOINT ["/bin/bash", "/source/run.sh"]

--- a/dockerfiles/generic/README.md
+++ b/dockerfiles/generic/README.md
@@ -1,0 +1,22 @@
+# Customizable platform based on ubuntu:latest
+
+## How to use generic platform:
+
+1. Place your dependencies in `prepare_buld.sh` (you can skip it)
+2. Place you build logic into `build.sh` (you can skip it)
+3. Launch your code in `run.sh` (code will be located at `/source/`)
+
+
+## Build algorithm:
+
+* a single file `./prepare_buld.sh` copied under `container:/source/prepare_buld.sh`
+* `/source/prepare_buld.sh` is launched before the build step to setup dependencies and caches
+* all code from the repository is placed under `container:/source/` folder
+* `/source/buld.sh` will be called at the build step
+* `/source/run.sh` will be called as an entry point for your solution
+
+### Notes:
+
+* `/source/run.sh` might be generated or modified by `build.sh`
+* `prepare_buld.sh` must not depend on any other file in the repository
+* `prepare_buld.sh` should be used for installing packages and getting extra dependencies, it should not change too frequently and required to make builds faster

--- a/dockerfiles/generic/build.sh
+++ b/dockerfiles/generic/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e # do not proceed if we failed somewhere
+
+# Replace contents with anything you need to do on the build step
+# Here you can access internet and install additional packages with apt-get install
+# You can also compile you application and place all the needed data where you expect it
+
+# Note: if you install packages with apt-get don't forget to run 
+# apt-get clean && rm -rf /var/lib/apt/lists/*
+# or you might end up in weird caching issues
+
+
+mkdir -p /data
+echo "Hello, World!" > /data/greeting.txt
+

--- a/dockerfiles/generic/prepare_build.sh
+++ b/dockerfiles/generic/prepare_build.sh
@@ -16,5 +16,7 @@ set -e # do not proceed if we failed somewhere
 #       Please be kind and move as much as possible here (and don't change it too often)
 
 
-apt-get install less # just a small package to make an example
+# Uncomment the following line and put some packages there
+# apt-get install <something>
+
 apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/generic/prepare_build.sh
+++ b/dockerfiles/generic/prepare_build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e # do not proceed if we failed somewhere
+
+# Replace contents with anything you need to do BEFORE the build step
+# This is the best place to download any external dependency and install additional packages
+
+# Note: if you install packages with apt-get don't forget to run
+# `apt-get clean && rm -rf /var/lib/apt/lists/*`
+# or you might end up in weird caching issues
+
+# Note: this must be a self-contained file and should not depent on any other file in your repo
+
+# Note: all the same can be done in build.sh, this file purely exists to speed-up build times
+#       and help orgamizer's team with possible cache issues
+#       Please be kind and move as much as possible here (and don't change it too often)
+
+
+apt-get install less # just a small package to make an example
+apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/generic/run.sh
+++ b/dockerfiles/generic/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Just replace contents with
+# exec $your_binary $your_extra_flags $@
+
+exec /bin/echo `cat /data/greeting.txt` and $@


### PR DESCRIPTION
This offers a generic platform that can be used to easily bootstrap any language or technology.
It provides both build-time extension point and run-time extension point.
It also provides a `prepare_build.sh` script in attempt to make the build faster and cache friendly.

This is a followup to the discussion in #11 


Tested locally:
```
➜  generic git:(generic_image) docker build .
Sending build context to Docker daemon  8.192kB
Step 1/9 : FROM ubuntu:20.04
 ---> 74435f89ab78
Step 2/9 : RUN apt-get update && apt-get install -y locales     build-essential openssl libssl-dev ca-certificates     && apt-get clean     && rm -rf /var/lib/apt/lists/*     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ---> Using cache
 ---> 48eb127c62ef
Step 3/9 : ENV LANG en_US.utf8
 ---> Using cache
 ---> 1ea6eb467afb
Step 4/9 : WORKDIR /source
 ---> Using cache
 ---> 3523da384f71
Step 5/9 : COPY ./prepare_build.sh .
 ---> b3f9a2d729f8
Step 6/9 : RUN /bin/bash /source/prepare_build.sh
 ---> Running in 2b3dbdc45330
Removing intermediate container 2b3dbdc45330
 ---> 0c68c165efd7
Step 7/9 : COPY . .
 ---> c0f6bd3483cb
Step 8/9 : RUN /bin/bash /source/build.sh
 ---> Running in 53e4646e42e7
Removing intermediate container 53e4646e42e7
 ---> 708c6808d48b
Step 9/9 : ENTRYPOINT ["/bin/bash", "/source/run.sh"]
 ---> Running in bec24911c549
Removing intermediate container bec24911c549
 ---> b11b74861e80
Successfully built b11b74861e80
➜  generic git:(generic_image) docker run -it --rm b11b74861e80 'Whos there?'
Hello, World! and Whos there?
```