### PR TITLE
Use cargo to build Rust apps with vendored dependencies

### DIFF
--- a/dockerfiles/rust/Cargo.toml
+++ b/dockerfiles/rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+isahc = "0.6"
+openssl = { version = "0.10", features = ["vendored"] }

--- a/dockerfiles/rust/Dockerfile
+++ b/dockerfiles/rust/Dockerfile
@@ -1,11 +1,11 @@
-FROM rust:slim-stretch AS build
+FROM rust:1.44.1-buster AS build
 WORKDIR /source
 
 COPY . .
 WORKDIR /source/app
-RUN rustc -O main.rs
+RUN cargo build --release
 
 FROM debian:buster-20200607-slim
-WORKDIR /build
-COPY --from=build /source/app/main .
-ENTRYPOINT ["./main"]
+WORKDIR /target
+COPY --from=build /source/target/release/app .
+ENTRYPOINT ["./app"]

--- a/dockerfiles/rust/Dockerfile
+++ b/dockerfiles/rust/Dockerfile
@@ -1,11 +1,11 @@
-FROM rust:1.44.1-buster AS build
+FROM icfpcontest2020/rust:latest AS build
 WORKDIR /source
 
 COPY . .
-WORKDIR /source/app
-RUN cargo build --release
+RUN cargo build --release --offline
 
 FROM debian:buster-20200607-slim
 WORKDIR /target
+
 COPY --from=build /source/target/release/app .
 ENTRYPOINT ["./app"]

--- a/dockerfiles/rust/Dockerfile.base
+++ b/dockerfiles/rust/Dockerfile.base
@@ -1,0 +1,6 @@
+FROM rust:1.44.1-buster
+WORKDIR /source
+
+COPY Cargo.toml .
+COPY src/ .
+RUN cargo vendor

--- a/dockerfiles/rust/README.md
+++ b/dockerfiles/rust/README.md
@@ -1,0 +1,1 @@
+Guaranteed to work with [starterkit-rust](https://github.com/icfpcontest2020/starterkit-rust).


### PR DESCRIPTION
Works with this PR: https://github.com/icfpcontest2020/starterkit-rust/pull/1/files