### PR TITLE
Use Stack in the Haskell image and add some libraries

### DIFF
--- a/dockerfiles/haskell/Dockerfile
+++ b/dockerfiles/haskell/Dockerfile
@@ -2,10 +2,10 @@ FROM icfpcontest2020/haskell:latest AS build
 WORKDIR /source
 
 COPY . .
-WORKDIR /source/app
-RUN ghc Main.hs
+WORKDIR /source
+RUN stack install --allow-different-user
 
 FROM debian:buster-20200607-slim
 WORKDIR /build
-COPY --from=build /source/app/Main .
-ENTRYPOINT ["./Main"]
+COPY --from=build /root/.local/bin/main .
+ENTRYPOINT ["./main"]

--- a/dockerfiles/haskell/Dockerfile.base
+++ b/dockerfiles/haskell/Dockerfile.base
@@ -1,1 +1,30 @@
-FROM haskell:8.10.1
+FROM haskell:8.8.3
+
+ARG STACK_RESOLVER=lts-16.3
+
+RUN stack update && \
+  stack install --resolver ${STACK_RESOLVER} \
+    aeson \
+    array \
+    attoparsec \
+    bytestring \
+    cereal \
+    containers \
+    deepseq \
+    directory \
+    filepath \
+    hashable \
+    http-conduit \
+    io-streams \
+    lens \
+    monad-control \
+    MonadRandom \
+    mtl \
+    optparse-applicative \
+    random \
+    text \
+    time \
+    transformers \
+    transformers-base \
+    unordered-containers \
+    vector


### PR DESCRIPTION
This addresses #8. In addition to the libraries mentioned there, I've also added [http-conduit](https://hackage.haskell.org/package/http-conduit) because it looks like submissions will need to deal with HTTP requests.

The non-base Dockerfile still uses separate images for building and running the submission, so there is the implicit assumption that the Stack project is configured to generate a statically linked binary.

I ~~will also make~~ made a [pull request](https://github.com/icfpcontest2020/starterkit-haskell/pull/1) to [starterkit-haskell](https://github.com/icfpcontest2020/starterkit-haskell) to make it compatible with these images.