### PR TITLE
First pass at Dockerfile for Elixir

### DIFF
--- a/dockerfiles/elixir/Dockerfile
+++ b/dockerfiles/elixir/Dockerfile
@@ -1,0 +1,14 @@
+FROM elixir:1.10.3-slim as Build
+
+WORKDIR /source
+COPY . .
+WORKDIR /source/app/
+RUN ./bin/build
+
+
+FROM debian:buster-20200607-slim
+
+ENV LANG=C.UTF-8
+WORKDIR /app
+COPY --from=Build /source/app/release ./
+ENTRYPOINT ["./run"]


### PR DESCRIPTION
Fixes https://github.com/icfpcontest2020/dockerfiles/issues/10

Let me know how this looks, I ran through what I **think** is the build process using the Elixir starterkit I also created:

1. copy Dockerfile into root of starterkit project
2. run `docker build --tag starterkit-elixir:1.0 .`
3. run `docker run starterkit-elixir:1.0 http://example.com whatever`

This results in a successful request to example.com with the second argument as the player key.

```
$ docker run starterkit-elixir:1.0 http://example.com whatever
server_url: "http://example.com"
player_key: "whatever"
'<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset="utf-8" />\n    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />\n    <meta name="viewport" content="width=device-width, initial-scale=1" />\n    <style type="text/css">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color: #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is for use in illustrative examples in documents. You may use this\n    domain in literature without prior coordination or asking for permission.</p>\n    <p><a href="https://www.iana.org/domains/example">More information...</a></p>\n</div>\n</body>\n</html>\n'
```