### PR TITLE
add cmake to cpp image

### DIFF
--- a/dockerfiles/cpp/Dockerfile.base
+++ b/dockerfiles/cpp/Dockerfile.base
@@ -2,6 +2,6 @@ FROM gcc:10.1.0
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends apt-utils && \
-    apt-get install -y --no-install-recommends libcurl4-openssl-dev libjansson-dev libgmp-dev qt5-default qtbase5-dev qt5-qmake qtbase5-dev-tools libboost1.67-all-dev && \
+    apt-get install -y --no-install-recommends libcurl4-openssl-dev libjansson-dev libgmp-dev qt5-default qtbase5-dev qt5-qmake qtbase5-dev-tools libboost1.67-all-dev cmake && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Our team usually does cross-platform development on windows/linux/mac using cmake to generate build files