### PR TITLE
Fix `docker build` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Submission system continuously checks every team's repository for updates in the
 1. Clone the repository into a clean directory, check out the appropriate branch.
 2. Read the first word from the `.platform` file.
 3. Create/replace a Dockerfile in the root directory with contents from `dockerfiles/<platform>/Dockerfile` of _this_ repository (not your team's repository). `<platform>` is the word from step 2.
-4. Run `docker build`. This step will run the `build.sh` script in your repository. Resulting image will be tagged with the commit hash and appear in the list of your submissions in your profile on the ICFPC web site, along with build logs. Assuming everything went well, your submission is now accepted and ready to run.
+4. Run `docker build .`. This step will run the `build.sh` script in your repository. Resulting image will be tagged with the commit hash and appear in the list of your submissions in your profile on the ICFPC web site, along with build logs. Assuming everything went well, your submission is now accepted and ready to run.
 
 There will be no Internet access during build. You will be limited to what your base Docker image provides and to the contents of your repository.
 


### PR DESCRIPTION
Running `docker build` without the `.` at the end results in:
```
$ docker build
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile
```

On the other hand, `docker build .` results in what I believe was the expected behaviour and output:
```
$ docker build .
Sending build context to Docker daemon  1.912MB
Step 1/7 : FROM icfpcontest2020/javascript
latest: Pulling from icfpcontest2020/javascript
81fc19181915: Already exists
ee49ee6a23d1: Already exists
828510924538: Already exists
a8f58c4fcca0: Already exists
33699d7df21e: Already exists
923705ffa8f8: Already exists
ae06f9217656: Pull complete
39c7f0f9ab3c: Pull complete
df076510734b: Pull complete
Digest: sha256:13c35ec2a3829f25171a8da49ea83366f7bf901cf0570002cd82769df49872be
Status: Downloaded newer image for icfpcontest2020/javascript:latest
 ---> dcda6cd5e439
Step 2/7 : WORKDIR /solution
 ---> Running in 0502697b3229
Removing intermediate container 0502697b3229
 ---> d7b272b37223
Step 3/7 : COPY . .
 ---> 04e6dba03433
Step 4/7 : RUN chmod +x ./build.sh
 ---> Running in 66d203471045
Removing intermediate container 66d203471045
 ---> bfeb00fbd55a
Step 5/7 : RUN chmod +x ./run.sh
 ---> Running in 97ed199c26f8
Removing intermediate container 97ed199c26f8
 ---> 0277913104c6
Step 6/7 : RUN ./build.sh
 ---> Running in 951191d0dabd
Build not required
Removing intermediate container 951191d0dabd
 ---> bd17283fb846
Step 7/7 : ENTRYPOINT ["./run.sh"]
 ---> Running in 78254cef1869
Removing intermediate container 78254cef1869
 ---> 1af61b935bb4
Successfully built 1af61b935bb4
```