### PR TITLE
Clarify the submission refs are under refs/heads/

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If your favorite language is missing, or you know a way to improve existing Dock
 
 ## Submission mechanism
 
-Submission system continuously checks every team's repository for updates in the `submission` and `submissions/*` branches. All other branches are ignored. New commits trigger a build which has the following steps:
+Submission system continuously checks every team's repository for updates in the `submission` and `submissions/*` branches (`refs/heads/submission` and `refs/heads/submissions/*` to be accurate). All other branches are ignored. New commits trigger a build which has the following steps:
 
 1. Clone the repository into a clean directory, check out the appropriate branch.
 2. Read the first word from the `.platform` file.


### PR DESCRIPTION
The document has no issue, but clarify the ref name. I tested to see if
the system picks up refs under refs/submissions/*, but it didn't. I
suppose that they really need to be branches (i.e. refs under
refs/heads/), not other refs.