### PR TITLE
ocaml: Add curl

### DIFF
--- a/dockerfiles/ocaml/Dockerfile.base
+++ b/dockerfiles/ocaml/Dockerfile.base
@@ -29,6 +29,7 @@ RUN opam update && \
     lwt \
     menhir \
     ocamlbuild \
+    ocurl \
     ounit2 \
     owl \
     ppx_deriving \


### PR DESCRIPTION
@beevee, your OCaml build farm has more work to do. :sweat_smile:

These are bindings to Curl, which is a much less complicated HTTP client than `cohttp` -- it doesn't require threads, monads, build system hackery. Wish I knew about it earlier.

I will update the starterkit to use this package.