### PR TITLE
Use AdoptOpenJDK for Scala

### DIFF
--- a/dockerfiles/scala/Dockerfile.base
+++ b/dockerfiles/scala/Dockerfile.base
@@ -1,6 +1,4 @@
-FROM openjdk:14-jdk-alpine
-
-RUN apk add --no-cache curl bash
+FROM adoptopenjdk:14-jre-hotspot
 
 ENV SCALA_URL='https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.tgz'
 ENV SCALA_HOME='/usr/local/share/scala'


### PR DESCRIPTION
This is an attempt to fix https://github.com/icfpcontest2020/dockerfiles/issues/83.

Not sure what is happening with that JRE but perhaps AdoptOpenJDK will work better.